### PR TITLE
Fix mnemonic confirmation

### DIFF
--- a/navigation/CreateNewWallet.tsx
+++ b/navigation/CreateNewWallet.tsx
@@ -26,7 +26,7 @@ const CreateNewWallet = () => {
   const {njs} = useNjs();
   const {read} = useKeychain();
 
-  const [words, setWords] = useState([]);
+  const [words, setWords] = useState<string[]>([]);
 
   return (
     <Container useSafeArea>
@@ -180,7 +180,9 @@ const CreateNewWallet = () => {
                       autoCapitalize="none"
                       value={words[wordpos]}
                       onChangeText={(name: string) => {
-                        setWords((prev) => prev[wordpos] = name.toLowerCase());
+                        let newWords = [...words];
+                        newWords[wordpos] = name.toLowerCase();
+                        setWords(newWords);
                       }}
                     />
                   </View>


### PR DESCRIPTION
This PR fixes a bug which did not allow to enter the mnemonic words in the confirmation step of the Create New Wallet screen.