### PR TITLE
Allow unconfirmed spending of public coins

### DIFF
--- a/components/BalanceCard.tsx
+++ b/components/BalanceCard.tsx
@@ -72,7 +72,7 @@ const BalanceCard = ({item, index, onPress}: BalanceProps) => {
             ) : (
               <CurrencyText
                 category="footnote"
-                children={amount + pending_amount}
+                children={(amount + pending_amount).toFixed(8)}
                 marginTop={4}
                 type={type_id}
                 formatType={type_id}

--- a/components/BalanceCircle.tsx
+++ b/components/BalanceCircle.tsx
@@ -139,7 +139,7 @@ const BalanceCircle = memo(() => {
       ) : (
         <View style={{position: 'absolute'}}>
           <Text style={{textAlign: 'center'}}>Balance:</Text>
-          <CurrencyText children={totalBalance} />
+          <CurrencyText children={totalBalance.toFixed(8)} />
         </View>
       )}
     </View>

--- a/components/CurrencyText.tsx
+++ b/components/CurrencyText.tsx
@@ -81,16 +81,20 @@ const CurrencyText = memo(
       if (currency.substring(0, 4) == 'item') {
         textResult = parseInt(amount);
       } else {
-        try {
-          if (isNaN(parseFloat(amount))) {
-            textResult += numeral(parseFloat(amount.replace(',', ''))).format(
-              '0,0.00',
-            );
-          } else {
-            textResult += numeral(parseFloat(amount)).format('0,0.00');
+        if (parseFloat(amount) > 0 && parseFloat(amount) < 0.01) {
+          textResult += '<0.01';
+        } else {
+          try {
+            if (isNaN(parseFloat(amount))) {
+              textResult += numeral(parseFloat(amount.replace(',', ''))).format(
+                '0,0.00',
+              );
+            } else {
+              textResult += numeral(parseFloat(amount)).format('0,0.00');
+            }
+          } catch (e) {
+            console.log(e);
           }
-        } catch (e) {
-          console.log(e);
         }
       }
       return textResult + ` ${currency}`;

--- a/constants/Type.tsx
+++ b/constants/Type.tsx
@@ -31,6 +31,7 @@ export interface BalanceFragment {
   name: string;
   amount: number;
   pending_amount: number;
+  spendable_amount: number;
   type_id: Balance_Types_Enum;
   destination_id: Destination_Types_Enum;
   currency: string;

--- a/contexts/WalletProvider.tsx
+++ b/contexts/WalletProvider.tsx
@@ -44,6 +44,7 @@ export const WalletProvider = (props: any) => {
       name: 'Public',
       amount: 0,
       pending_amount: 0,
+      spendable_amount: 0,
       type_id: Balance_Types_Enum.Nav,
       destination_id: Destination_Types_Enum.PublicWallet,
       currency: 'NAV',
@@ -52,6 +53,7 @@ export const WalletProvider = (props: any) => {
       name: 'Private',
       amount: 0,
       pending_amount: 0,
+      spendable_amount: 0,
       type_id: Balance_Types_Enum.xNav,
       destination_id: Destination_Types_Enum.PrivateWallet,
       currency: 'xNAV',
@@ -60,6 +62,7 @@ export const WalletProvider = (props: any) => {
       name: 'Staking',
       amount: 0,
       pending_amount: 0,
+      spendable_amount: 0,
       type_id: Balance_Types_Enum.Staking,
       destination_id: Destination_Types_Enum.StakingWallet,
       currency: 'NAV',
@@ -144,6 +147,8 @@ export const WalletProvider = (props: any) => {
           name: 'Public',
           amount: balances.nav.confirmed / 1e8,
           pending_amount: balances.nav.pending / 1e8,
+          spendable_amount:
+            (balances.nav.confirmed + balances.nav.pending) / 1e8,
           type_id: Balance_Types_Enum.Nav,
           destination_id: Destination_Types_Enum.PublicWallet,
           currency: 'NAV',
@@ -153,6 +158,7 @@ export const WalletProvider = (props: any) => {
           name: 'Private',
           amount: balances.xnav.confirmed / 1e8,
           pending_amount: balances.xnav.pending / 1e8,
+          spendable_amount: balances.xnav.confirmed / 1e8,
           type_id: Balance_Types_Enum.xNav,
           destination_id: Destination_Types_Enum.PrivateWallet,
           currency: 'xNAV',
@@ -167,6 +173,10 @@ export const WalletProvider = (props: any) => {
           name: label + ' Staking',
           amount: addresses.staking[address].staking.confirmed / 1e8,
           pending_amount: addresses.staking[address].staking.pending / 1e8,
+          spendable_amount:
+            (addresses.staking[address].staking.confirmed +
+              addresses.staking[address].staking.pending) /
+            1e8,
           type_id: Balance_Types_Enum.Staking,
           destination_id: Destination_Types_Enum.StakingWallet,
           address: address,
@@ -182,6 +192,7 @@ export const WalletProvider = (props: any) => {
           name: balances.tokens[tokenId].name,
           amount: (balances.tokens[tokenId].confirmed || 0) / 1e8,
           pending_amount: (balances.tokens[tokenId].pending || 0) / 1e8,
+          spendable_amount: (balances.tokens[tokenId].confirmed || 0) / 1e8,
           type_id: Balance_Types_Enum.PrivateToken,
           destination_id: Destination_Types_Enum.PrivateWallet,
           tokenId: tokenId,
@@ -193,11 +204,12 @@ export const WalletProvider = (props: any) => {
       let nft = [];
 
       for (let tokenId in balances.nfts) {
-        console.log(balances.nfts[tokenId]);
         nft.push({
           name: balances.nfts[tokenId].name,
           amount: Object.keys(balances.nfts[tokenId].confirmed).length,
           pending_amount: Object.keys(balances.nfts[tokenId].pending).length,
+          spendable_amount: Object.keys(balances.nfts[tokenId].confirmed)
+            .length,
           type_id: Balance_Types_Enum.Nft,
           destination_id: Destination_Types_Enum.PrivateWallet,
           tokenId: tokenId,
@@ -241,8 +253,6 @@ export const WalletProvider = (props: any) => {
         wallet.Disconnect();
       }
 
-      console.log('walletfile', name, password, spendingPassword);
-
       const walletFile = new njs.wallet.WalletFile({
         file: name,
         mnemonic: mnemonic_,
@@ -269,7 +279,6 @@ export const WalletProvider = (props: any) => {
 
       walletFile.on('loaded', async () => {
         console.log('loaded');
-        console.log(walletFile.type);
         walletFile.GetBalance().then(setBalances);
         walletFile.GetHistory().then(setHistory);
         njs.wallet.WalletFile.ListWallets().then(setWalletsList);
@@ -359,14 +368,8 @@ export const WalletProvider = (props: any) => {
           let fee = 0;
 
           for (let c of candidates) {
-            console.log(
-              'candidate fee',
-              parseInt(BigInt(c.fee.words).toString()),
-            );
             fee += parseInt(BigInt(c.fee.words).toString());
           }
-
-          console.log('using', fee);
 
           let obj =
             from == 'token' || from == 'nft'
@@ -433,7 +436,6 @@ export const WalletProvider = (props: any) => {
             0x1,
             fromAddress,
           );
-          console.log(ret);
           res(ret);
         } else if (from == 'cold_staking') {
           let ret = await wallet.NavCreateTransaction(
@@ -446,7 +448,6 @@ export const WalletProvider = (props: any) => {
             0x2,
             fromAddress,
           );
-          console.log(ret);
           res(ret);
         } else {
           console.log('unknown wallet type', from);

--- a/contexts/WalletProvider.tsx
+++ b/contexts/WalletProvider.tsx
@@ -254,8 +254,6 @@ export const WalletProvider = (props: any) => {
         wallet.Disconnect();
       }
 
-      console.log('walletfile', name, password, spendingPassword);
-
       const walletFile = new njs.wallet.WalletFile({
         file: name,
         mnemonic: mnemonic_,
@@ -282,7 +280,6 @@ export const WalletProvider = (props: any) => {
 
       walletFile.on('loaded', async () => {
         console.log('loaded');
-        console.log(walletFile.type);
         walletFile.GetBalance().then(setBalances);
         walletFile.GetHistory().then(setHistory);
         njs.wallet.WalletFile.ListWallets().then(setWalletsList);
@@ -364,7 +361,6 @@ export const WalletProvider = (props: any) => {
         rej('Wallet not loaded');
         return;
       }
-      console.log('wp am', Math.floor(amount * 1e8), amount);
       try {
         if (from == 'xnav' || from == 'token' || from == 'nft') {
           let candidates = (await wallet.GetCandidates())
@@ -374,14 +370,8 @@ export const WalletProvider = (props: any) => {
           let fee = 0;
 
           for (let c of candidates) {
-            console.log(
-              'candidate fee',
-              parseInt(BigInt(c.fee.words).toString()),
-            );
             fee += parseInt(BigInt(c.fee.words).toString());
           }
-
-          console.log('using', fee);
 
           let obj =
             from == 'token' || from == 'nft'
@@ -448,7 +438,6 @@ export const WalletProvider = (props: any) => {
             0x1,
             fromAddress,
           );
-          console.log(ret);
           res(ret);
         } else if (from == 'cold_staking') {
           let ret = await wallet.NavCreateTransaction(
@@ -461,7 +450,6 @@ export const WalletProvider = (props: any) => {
             0x2,
             fromAddress,
           );
-          console.log(ret);
           res(ret);
         } else {
           console.log('unknown wallet type', from);

--- a/screens/wallet/SendToScreen.tsx
+++ b/screens/wallet/SendToScreen.tsx
@@ -77,7 +77,7 @@ const SendToScreen = (props: any) => {
     if (!el) {
       return 0;
     } else {
-      return el.currency == 'NAV' ? el.amount + el?.pending_amount : el.amount;
+      return el.spendable_amount;
     }
   }, [from, sources]);
 
@@ -136,7 +136,12 @@ const SendToScreen = (props: any) => {
                 return {
                   ...el,
                   text:
-                    el.name + ' Wallet (' + el.amount + ' ' + el.currency + ')',
+                    el.name +
+                    ' Wallet (' +
+                    el.spendable_amount +
+                    ' ' +
+                    el.currency +
+                    ')',
                 };
               })}
               text={'From'}
@@ -151,7 +156,12 @@ const SendToScreen = (props: any) => {
                   return '';
                 }
                 return (
-                  el.name + ' Wallet (' + el.amount + ' ' + el.currency + ')'
+                  el.name +
+                  ' Wallet (' +
+                  el.spendable_amount +
+                  ' ' +
+                  el.currency +
+                  ')'
                 );
               })()}
               onSelect={el => {


### PR DESCRIPTION
For public balances (staking or public wallets), unconfirmed funds should be allowed to be spent and shown as available balance.

In order to test it, move coins between public and staking wallets, and try to send them immediately again while the balance appears in pending in the `BalanceFragment`.