### PR TITLE
Fix timer bootstrap

### DIFF
--- a/components/BalanceCircle.tsx
+++ b/components/BalanceCircle.tsx
@@ -39,6 +39,7 @@ const BalanceCircle = memo(() => {
       setRotation(180);
       BackgroundTimer.stopBackgroundTimer();
     } else {
+      BackgroundTimer.stopBackgroundTimer();
       BackgroundTimer.runBackgroundTimer(() => {
         setRotation(prev => {
           return prev + 2;

--- a/components/BalanceCircle.tsx
+++ b/components/BalanceCircle.tsx
@@ -6,6 +6,7 @@ import useWallet from '../hooks/useWallet';
 import {useTheme, Text} from '@ui-kitten/components';
 import {Connection_Stats_Enum} from '../constants/Type';
 import CurrencyText from './CurrencyText';
+import BackgroundTimer from 'react-native-background-timer';
 
 const BalanceCircle = memo(() => {
   const {width} = useLayout();
@@ -29,7 +30,6 @@ const BalanceCircle = memo(() => {
   ]);
   const [totalBalance, setTotalBalance] = useState(0);
   const [rotation, setRotation] = useState(180);
-  const [timer, setTimer] = useState<any>(undefined);
 
   useEffect(() => {
     if (
@@ -37,15 +37,13 @@ const BalanceCircle = memo(() => {
       connected != Connection_Stats_Enum.Bootstrapping
     ) {
       setRotation(180);
-      clearInterval(timer);
+      BackgroundTimer.stopBackgroundTimer();
     } else {
-      setTimer(
-        setInterval(() => {
-          setRotation(prev => {
-            return prev + 2;
-          });
-        }, 10),
-      );
+      BackgroundTimer.runBackgroundTimer(() => {
+        setRotation(prev => {
+          return prev + 2;
+        });
+      }, 10);
     }
   }, [connected]);
 

--- a/components/BalanceCircle.tsx
+++ b/components/BalanceCircle.tsx
@@ -7,6 +7,7 @@ import {useTheme, Text} from '@ui-kitten/components';
 import {Connection_Stats_Enum} from '../constants/Type';
 import CurrencyText from './CurrencyText';
 import BackgroundTimer from 'react-native-background-timer';
+import Animated from 'react-native-reanimated';
 
 const BalanceCircle = memo(() => {
   const {width} = useLayout();
@@ -36,13 +37,13 @@ const BalanceCircle = memo(() => {
       connected != Connection_Stats_Enum.Connecting &&
       connected != Connection_Stats_Enum.Bootstrapping
     ) {
-      setRotation(180);
       BackgroundTimer.stopBackgroundTimer();
+      setRotation(180);
     } else {
       BackgroundTimer.stopBackgroundTimer();
       BackgroundTimer.runBackgroundTimer(() => {
         setRotation(prev => {
-          return prev + 2;
+          return (prev + 2) % 360;
         });
       }, 10);
     }
@@ -84,7 +85,12 @@ const BalanceCircle = memo(() => {
         marginBottom: 16,
       }}>
       <SegmentCircle
-        initialRotation={rotation}
+        initialRotation={
+          connected != Connection_Stats_Enum.Connecting &&
+          connected != Connection_Stats_Enum.Bootstrapping
+            ? 180
+            : rotation
+        }
         radius={width / 2 - 100}
         background={
           connected == Connection_Stats_Enum.Connecting ||
@@ -138,7 +144,7 @@ const BalanceCircle = memo(() => {
       ) : (
         <View style={{position: 'absolute'}}>
           <Text style={{textAlign: 'center'}}>Balance:</Text>
-          <CurrencyText children={totalBalance} />
+          <CurrencyText children={totalBalance.toFixed(8)} />
         </View>
       )}
     </View>

--- a/components/BalanceCircle.tsx
+++ b/components/BalanceCircle.tsx
@@ -7,7 +7,6 @@ import {useTheme, Text} from '@ui-kitten/components';
 import {Connection_Stats_Enum} from '../constants/Type';
 import CurrencyText from './CurrencyText';
 import BackgroundTimer from 'react-native-background-timer';
-import Animated from 'react-native-reanimated';
 
 const BalanceCircle = memo(() => {
   const {width} = useLayout();

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "punycode": "^1.4.1",
     "react": "17.0.2",
     "react-native": "0.66.4",
+    "react-native-background-timer": "^2.4.1",
     "react-native-big-list": "^1.5.2",
     "react-native-bootsplash": "^4.1.4",
     "react-native-camera": "^4.2.1",


### PR DESCRIPTION
This PR introduces a patch to fix the timer which creates the infinite rotation of the BalanceCircle during `bootstrap` phase.

Old behaviour:

https://user-images.githubusercontent.com/24814046/163582582-f67fab29-6038-47fa-89fa-4092c293970c.mp4

Animation speeds up when app goes to the background.

New behaviour:

Animation runs smooth.
